### PR TITLE
Make EVM signer Web3 imports lazy

### DIFF
--- a/ultrade/signers/ethereum.py
+++ b/ultrade/signers/ethereum.py
@@ -2,8 +2,6 @@ from ultrade.utils.encode import determine_address_type, normalize_address
 from ultrade.types import Technology, WormholeChains
 from ultrade.constants import TMC_ABI as abi, ERC20_ABI
 from ultrade import Signer
-from web3 import Web3, HTTPProvider
-from web3.middleware import geth_poa_middleware
 from eth_account import Account
 from eth_keys import keys
 from coincurve import PrivateKey as _CoinPrivateKey
@@ -12,6 +10,17 @@ from eth_hash.auto import keccak as _keccak
 GAS_LIMIT = 1000000
 
 _EIP191_PREFIX = b"\x19Ethereum Signed Message:\n"
+
+
+def _load_web3_deposit_dependencies():
+    from web3 import Web3, HTTPProvider
+
+    try:
+        from web3.middleware import ExtraDataToPOAMiddleware as poa_middleware
+    except ImportError:
+        from web3.middleware import geth_poa_middleware as poa_middleware
+
+    return Web3, HTTPProvider, poa_middleware
 
 
 class EthereumSigner(Signer):
@@ -52,6 +61,8 @@ class EthereumSigner(Signer):
             amount (int): The amount of tokens to deposit.
             token_address (str | int): The id of the token to deposit.
         """
+        Web3, HTTPProvider, poa_middleware = _load_web3_deposit_dependencies()
+
         if not Web3.is_address(token_address):
             raise Exception("You must provide a valid EVM token address.")
 
@@ -72,7 +83,7 @@ class EthereumSigner(Signer):
             raise Exception("RPC URL is not set. Please provide a valid RPC URL.")
 
         web3 = Web3(HTTPProvider(rpc_url))
-        web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+        web3.middleware_onion.inject(poa_middleware, layer=0)
 
         if not web3.is_connected():
             raise Exception(


### PR DESCRIPTION
## Summary
- move Web3 and POA middleware imports out of the module import path and into deposit-only loading
- support both Web3 v7 `ExtraDataToPOAMiddleware` and older `geth_poa_middleware`
- keep the coincurve `sign_data` path importable in environments where Web3 middleware names differ

## Validation
- `PYTHONPYCACHEPREFIX=/tmp/ultrade-pycache python3 -m py_compile ultrade/signers/ethereum.py`
- verified in the Hummingbot Docker image that `EthereumSigner.sign_data()` matches `eth_account` output for a sample message